### PR TITLE
Fix CSS class typo

### DIFF
--- a/components/speaker.css
+++ b/components/speaker.css
@@ -12,7 +12,7 @@
   object-fit: cover;
   aspect-ratio: 1;
 }
-.speaker-deails {
+.speaker-details {
   gap: var(--dl-space-space-halfunit);
   display: flex;
   align-items: flex-start;

--- a/components/speaker.html
+++ b/components/speaker.html
@@ -52,7 +52,7 @@
           src="public/speakers-1-1500w.png"
           class="speaker-image"
         />
-        <div class="speaker-deails">
+        <div class="speaker-details">
           <h3 class="speaker-name"><span>Samantha Johnson</span></h3>
           <div class="speaker-position">
             <div class="speaker-point"></div>


### PR DESCRIPTION
## Summary
- rename `.speaker-deails` to `.speaker-details`
- update markup to use `.speaker-details`

## Testing
- `grep -R speaker-deails -n`


------
https://chatgpt.com/codex/tasks/task_e_6854049fb33883278ed1daacfa1b1b5e